### PR TITLE
【client：資料一覧】スマホ操作でフォルダが開かず、PDFファイルの閲覧不可(No43)

### DIFF
--- a/src/components/manager/TableView.vue
+++ b/src/components/manager/TableView.vue
@@ -72,11 +72,15 @@
                     v-on:click="selectItem('files', file.path, $event)"
                     v-on:touchstart="selectItem('files', file.path, $event)"
                     v-on:dblclick="selectAction(file.path, file.extension)"
-                    v-on:touchend="selectAction(file.path, file.extension)"
                     v-on:contextmenu.prevent="contextMenu(file, $event)"
                     style="position: relative;"
                 >
-                    <td class="fm-content-item unselectable" v-bind:class="acl && file.acl === 0 ? 'text-hidden' : ''" @mouseleave="hidePopup()">
+                    <td
+                        class="fm-content-item unselectable"
+                        v-bind:class="acl && file.acl === 0 ? 'text-hidden' : ''"
+                        v-on:mouseleave="hidePopup()"
+                        v-on:touchend="selectAction(file.path, file.extension)"
+                    >
                         <i class="bi icon" v-bind:class="extensionToIcon(file.extension)" @mouseenter="showImagePopup(index); setImgSrc(file);" />
                         <span class="filename" @mouseenter="showTitlePopup(index)" >{{ file.filename ? abbriviatedString(file.filename, 15) : abbriviatedString(file.basename, 15) }}</span>
                         <span v-if="isFileNew(file.timestamp)" class="new-indicator">NEW</span>

--- a/src/components/manager/TableView.vue
+++ b/src/components/manager/TableView.vue
@@ -47,12 +47,14 @@
                     v-bind:key="`d-${index}`"
                     v-bind:class="{ 'table-info': checkSelect('directories', directory.path) }"
                     v-on:click="selectItem('directories', directory.path, $event)"
+                    v-on:touchstart="selectItem('directories', directory.path, $event)"
                     v-on:contextmenu.prevent="contextMenu(directory, $event)"
                 >
                     <td
                         class="fm-content-item unselectable"
                         v-bind:class="acl && directory.acl === 0 ? 'text-hidden' : ''"
                         v-on:dblclick="selectDirectory(directory.path)"
+                        v-on:touchend="selectDirectory(directory.path)"
                     >
                         <i class="bi bi-folder"></i> {{ directory.basename }}
                     </td>
@@ -68,7 +70,9 @@
                     v-bind:key="`f-${index}`"
                     v-bind:class="{ 'table-info': checkSelect('files', file.path) }"
                     v-on:click="selectItem('files', file.path, $event)"
+                    v-on:touchstart="selectItem('files', file.path, $event)"
                     v-on:dblclick="selectAction(file.path, file.extension)"
+                    v-on:touchend="selectAction(file.path, file.extension)"
                     v-on:contextmenu.prevent="contextMenu(file, $event)"
                     style="position: relative;"
                 >


### PR DESCRIPTION
## プルリク概要
https://github.com/beyonds-inc/eportal-saas/issues/172
上記issueに対応

## 改修内容
スマホ・タブレットのタッチでディレクトリ移動やPDF閲覧などの操作ができるように修正
