### PR TITLE
【残課題alexusmai#10】資料一覧の資料URLのコピー <ePortal issue #208>

### DIFF
--- a/src/components/blocks/mixins/contextMenuActions.js
+++ b/src/components/blocks/mixins/contextMenuActions.js
@@ -110,7 +110,8 @@ export default {
          * Copy URL of selected item
          */
         copyUrlAction() {
-            var currentUrl = window.location.origin + window.location.pathname +
+            const PATH_NAME = '/medical/materials';
+            var currentUrl = window.location.origin + PATH_NAME +
                             '?leftDisk=' + encodeURIComponent(this.selectedDisk) +
                             '&leftPath=' + encodeURIComponent(this.selectedItems[0].dirname) +
                             '&baseName=' + encodeURIComponent(this.selectedItems[0].basename);

--- a/src/components/blocks/mixins/contextMenuActions.js
+++ b/src/components/blocks/mixins/contextMenuActions.js
@@ -1,5 +1,5 @@
 import HTTP from '../../../http/get';
-
+import EventBus from '../../../emitter';
 /**
  * Context menu actions
  * {name}Action
@@ -103,6 +103,21 @@ export default {
                     tempLink.click();
                     document.body.removeChild(tempLink);
                 }
+            });
+        },
+
+        /**
+         * Copy URL of selected item
+         */
+        copyUrlAction() {
+            var currentUrl = window.location.origin + window.location.pathname +
+                            '?leftDisk=' + this.selectedDisk +
+                            '&leftPath=' + this.selectedItems[0].dirname +
+                            '&baseName=' + this.selectedItems[0].basename;
+            navigator.clipboard.writeText(currentUrl);
+            EventBus.emit('addNotification', {
+                status: 'success',
+                message: this.lang.notifications.copyUrl,
             });
         },
 

--- a/src/components/blocks/mixins/contextMenuActions.js
+++ b/src/components/blocks/mixins/contextMenuActions.js
@@ -111,9 +111,9 @@ export default {
          */
         copyUrlAction() {
             var currentUrl = window.location.origin + window.location.pathname +
-                            '?leftDisk=' + this.selectedDisk +
-                            '&leftPath=' + this.selectedItems[0].dirname +
-                            '&baseName=' + this.selectedItems[0].basename;
+                            '?leftDisk=' + encodeURIComponent(this.selectedDisk) +
+                            '&leftPath=' + encodeURIComponent(this.selectedItems[0].dirname) +
+                            '&baseName=' + encodeURIComponent(this.selectedItems[0].basename);
             navigator.clipboard.writeText(currentUrl);
             EventBus.emit('addNotification', {
                 status: 'success',

--- a/src/components/blocks/mixins/contextMenuActions.js
+++ b/src/components/blocks/mixins/contextMenuActions.js
@@ -110,8 +110,7 @@ export default {
          * Copy URL of selected item
          */
         copyUrlAction() {
-            const PATH_NAME = '/medical/materials';
-            var currentUrl = window.location.origin + PATH_NAME +
+            var currentUrl = window.location.origin + window.location.pathname.replace('client', 'medical') +
                             '?leftDisk=' + encodeURIComponent(this.selectedDisk) +
                             '&leftPath=' + encodeURIComponent(this.selectedItems[0].dirname) +
                             '&baseName=' + encodeURIComponent(this.selectedItems[0].basename);

--- a/src/components/blocks/mixins/contextMenuRules.js
+++ b/src/components/blocks/mixins/contextMenuRules.js
@@ -67,6 +67,14 @@ export default {
         },
 
         /**
+         * Copy URL - menu item status - show or hide
+         * @returns {boolean}
+         */
+        copyUrlRule() {
+            return !this.multiSelect;
+        },
+
+        /**
          * Copy - menu item status - show or hide
          * @returns {boolean}
          */

--- a/src/lang/en.js
+++ b/src/lang/en.js
@@ -49,6 +49,7 @@ const en = {
         edit: 'Edit',
         audioPlay: 'Play',
         videoPlay: 'Play',
+        copyUrl: 'Copy URL',
     },
     info: {
         directories: 'Folders:',
@@ -157,6 +158,7 @@ const en = {
     notifications: {
         cutToClipboard: 'Cut to clipboard!',
         copyToClipboard: 'Copied to clipboard!',
+        copyUrl: 'URL copied!',
     },
     response: {
         noConfig: 'Config not found!',

--- a/src/lang/ja.js
+++ b/src/lang/ja.js
@@ -49,6 +49,7 @@ const ja = {
     edit: '編集',
     audioPlay: '再生',
     videoPlay: '動画再生',
+    copyUrl: 'URLコピー',
   },
   info: {
     directories: 'フォルダ:',
@@ -158,6 +159,7 @@ const ja = {
   notifications: {
     cutToClipboard: 'クリップボードに切り取りしました！',
     copyToClipboard: 'クリップボードにコピーしました！',
+    copyUrl: 'URLをコピーしました！',
   },
   response: {
     noConfig: '設定が見つかりませんでした！',

--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -27,6 +27,7 @@ export default {
                 // paths
                 let leftPath = response.data.config.leftPath;
                 let rightPath = response.data.config.rightPath;
+                let baseName = '';
 
                 // find disk and path settings in the URL
                 if (window.location.search) {
@@ -47,6 +48,10 @@ export default {
                     if (params.get('rightPath')) {
                         rightPath = params.get('rightPath');
                     }
+
+                    if (params.get('baseName')) {
+                        baseName = params.get('baseName');
+                    }
                 }
 
                 commit('left/setDisk', leftDisk);
@@ -55,6 +60,7 @@ export default {
                 if (leftPath) {
                     commit('left/setSelectedDirectory', leftPath);
                     commit('left/addToHistory', leftPath);
+                    commit('left/setSelected', { type: 'files', path: `${leftPath}/${baseName}` });
                 }
 
                 dispatch('getLoadContent', {

--- a/src/store/settings/store.js
+++ b/src/store/settings/store.js
@@ -105,6 +105,10 @@ export default {
                         name: 'download',
                         icon: 'bi-download',
                     },
+                    {
+                        name: 'copyUrl',
+                        icon: 'bi-link-45deg',
+                    }
                 ],
                 [
                     {


### PR DESCRIPTION
[ePortal issue #208](https://github.com/beyonds-inc/eportal-saas/issues/208)

## 改修内容
ファイル上で右クリック時出るコンテキストメニューに、「URLコピー」ボタンを追加。
ボタンをクリックすると、該当ファイルにアクセスできるURLをクリップボードにコピーする。（medical向けのURL）
成功時、画面右下に「URLをコピーしました！」と通知が出る。アクセスすると該当ファイルが選択されている。

## テスト
[2023-11-06-18-49-52.webm](https://github.com/beyonds-inc/vue-laravel-file-manager/assets/67548416/e6713b86-e341-4bd3-b71f-eb7f3031bf31)

