### PR TITLE
フォルダの右クリックメニュー表示復帰、上部バーのフォルダ生成ボタン再表示

### DIFF
--- a/src/components/blocks/NavbarBlock.vue
+++ b/src/components/blocks/NavbarBlock.vue
@@ -35,7 +35,7 @@ export default {
     mixins: [translate],
     data() {
         return {
-            isEditor: isEditor,
+            isEditor: Number(isEditor),
         };
     },
     computed: {

--- a/src/components/blocks/NavbarBlock.vue
+++ b/src/components/blocks/NavbarBlock.vue
@@ -4,7 +4,6 @@
             <div class="col-auto">
                 <div class="btn-group" role="group">
                     <button
-                        v-if="isEditor"
                         type="button"
                         class="btn btn-secondary"
                         v-on:click="showModal('NewFolderModal')"

--- a/src/components/blocks/NavbarBlock.vue
+++ b/src/components/blocks/NavbarBlock.vue
@@ -35,7 +35,7 @@ export default {
     mixins: [translate],
     data() {
         return {
-            isEditor: role === 'editor',
+            isEditor: isEditor,
         };
     },
     computed: {

--- a/src/components/blocks/NavbarBlock.vue
+++ b/src/components/blocks/NavbarBlock.vue
@@ -4,6 +4,15 @@
             <div class="col-auto">
                 <div class="btn-group" role="group">
                     <button
+                        v-if="role === 'editor'"
+                        type="button"
+                        class="btn btn-secondary"
+                        v-on:click="showModal('NewFolderModal')"
+                        v-bind:title="lang.btn.folder"
+                    >
+                        <i class="bi bi-folder"></i>
+                    </button>
+                    <button
                         type="button"
                         class="btn btn-secondary"
                         v-bind:disabled="!clipboardType"
@@ -24,6 +33,11 @@ import translate from '../../mixins/translate';
 export default {
     name: 'NavbarBlock',
     mixins: [translate],
+    data() {
+        return {
+            role: role, // role is defined in blade template
+        };
+    },
     computed: {
         /**
          * Active manager name
@@ -40,6 +54,11 @@ export default {
         clipboardType() {
             return this.$store.state.fm.clipboard.type;
         },
+        
+        /**
+         * Whether role is editor
+         * 
+         */
     },
     methods: {
         /**
@@ -47,6 +66,17 @@ export default {
          */
         paste() {
             this.$store.dispatch('fm/paste');
+        },
+        /**
+         * Show modal window
+         * @param modalName
+         */
+        showModal(modalName) {
+            // show selected modal
+            this.$store.commit('fm/modal/setModalState', {
+                modalName,
+                show: true,
+            });
         },
     },
 };

--- a/src/components/blocks/NavbarBlock.vue
+++ b/src/components/blocks/NavbarBlock.vue
@@ -54,11 +54,6 @@ export default {
         clipboardType() {
             return this.$store.state.fm.clipboard.type;
         },
-        
-        /**
-         * Whether role is editor
-         * 
-         */
     },
     methods: {
         /**

--- a/src/components/blocks/NavbarBlock.vue
+++ b/src/components/blocks/NavbarBlock.vue
@@ -4,7 +4,7 @@
             <div class="col-auto">
                 <div class="btn-group" role="group">
                     <button
-                        v-if="role === 'editor'"
+                        v-if="isEditor"
                         type="button"
                         class="btn btn-secondary"
                         v-on:click="showModal('NewFolderModal')"
@@ -35,7 +35,7 @@ export default {
     mixins: [translate],
     data() {
         return {
-            role: role, // role is defined in blade template
+            isEditor: role === 'editor',
         };
     },
     computed: {

--- a/src/components/blocks/mixins/contextMenuRules.js
+++ b/src/components/blocks/mixins/contextMenuRules.js
@@ -71,7 +71,7 @@ export default {
          * @returns {boolean}
          */
         copyUrlRule() {
-            return !this.multiSelect;
+            return !this.multiSelect && this.selectedItems[0].type === 'file';
         },
 
         /**
@@ -88,7 +88,7 @@ export default {
          * @returns {boolean}
          */
         cutRule() {
-            return this.$store.getters['fm/isEverySelectedItemRW'];
+            return this.$store.getters['fm/isEverySelectedItemRW'] && this.selectedItems.every((elem) => elem.type === 'file');
             // return false;
         },
 
@@ -139,6 +139,11 @@ export default {
          * @returns {boolean}
          */
         deleteRule() {
+            const isEditor = role === 'editor';
+            // forbid medical users from deleting folders
+            if (!this.selectedItems.every((elem) => elem.type === 'file') && !isEditor) {
+                return false;
+            }
             return this.$store.getters['fm/isEverySelectedItemRW'];
         },
 

--- a/src/components/blocks/mixins/contextMenuRules.js
+++ b/src/components/blocks/mixins/contextMenuRules.js
@@ -139,7 +139,6 @@ export default {
          * @returns {boolean}
          */
         deleteRule() {
-            const isEditor = role === 'editor';
             // forbid medical users from deleting folders
             if (!this.selectedItems.every((elem) => elem.type === 'file') && !isEditor) {
                 return false;

--- a/src/components/manager/mixins/manager.js
+++ b/src/components/manager/mixins/manager.js
@@ -138,9 +138,8 @@ export default {
             }
 
             // create event
-            if (type === 'files') {
-                EventBus.emit('contextMenu', event);
-            }
+            // @TODO: fix next errors; copying wrong url, not being able to paste folder, preventing copying url of folder
+            EventBus.emit('contextMenu', event);
         },
 
         /**

--- a/src/components/manager/mixins/manager.js
+++ b/src/components/manager/mixins/manager.js
@@ -138,7 +138,6 @@ export default {
             }
 
             // create event
-            // @TODO: fix next errors; copying wrong url, not being able to paste folder, preventing copying url of folder
             EventBus.emit('contextMenu', event);
         },
 


### PR DESCRIPTION
[ePortal issue 207](https://github.com/beyonds-inc/eportal-saas/issues/207)対応につれて、以下対応
- フォルダの右クリック復帰
→ フォルダの削除可能（管理者のみ）
- 上部バーのフォルダ生成ボタン復帰（管理者のみ）