### PR TITLE
施設アカウントにフォルダ作成ボタン再表示

### DIFF
--- a/src/components/blocks/NavbarBlock.vue
+++ b/src/components/blocks/NavbarBlock.vue
@@ -35,7 +35,7 @@ export default {
     mixins: [translate],
     data() {
         return {
-            isEditor: isEditor,
+            isEditor: Number(isEditor),
         };
     },
     computed: {

--- a/src/components/blocks/NavbarBlock.vue
+++ b/src/components/blocks/NavbarBlock.vue
@@ -4,7 +4,6 @@
             <div class="col-auto">
                 <div class="btn-group" role="group">
                     <button
-                        v-if="isEditor"
                         type="button"
                         class="btn btn-secondary"
                         v-on:click="showModal('NewFolderModal')"


### PR DESCRIPTION
## プルリク概要
施設アカウントにフォルダ作成ボタン再表示
・経緯：https://github.com/beyonds-inc/eportal-saas/pull/272

## 関連issue
■ ePortal
[#207 ](https://github.com/beyonds-inc/eportal-saas/issues/207)
[#272 ](https://github.com/beyonds-inc/eportal-saas/pull/272)