### PR TITLE
メッセージの内容変更

### DIFF
--- a/src/lang/ja.js
+++ b/src/lang/ja.js
@@ -107,7 +107,7 @@ const ja = {
       access_2: '読み書き可能',
     },
     rename: {
-      directoryExist: 'ディレクトリが既に存在します',
+      directoryExist: 'フォルダが既に存在します',
       fieldName: '新しい名前を入力してください',
       fieldFeedback: 'この名前は使用できません',
       fileExist: 'ファイルが既に存在します',
@@ -173,9 +173,9 @@ const ja = {
     fileUpdated: 'ファイルを更新しました！',
     fileNotFound: 'ファイルが見つかりませんでした！',
     // directories
-    dirExist: 'ディレクトリが既に存在します！',
-    dirCreated: 'ディレクトリを生成しました！',
-    dirNotFound: 'ディレクトリが見つかりませんでした',
+    dirExist: 'フォルダが既に存在します！',
+    dirCreated: 'フォルダを生成しました！',
+    dirNotFound: 'フォルダが見つかりませんでした',
     // actions
     uploaded: 'ファイルを全てアップロードしました！',
     notAllUploaded: 'ファイルの一部がアップロードできませんでした！',

--- a/src/lang/ja.js
+++ b/src/lang/ja.js
@@ -76,17 +76,17 @@ const ja = {
       version: 'バージョン',
     },
     delete: {
-      noSelected: 'ファイルを選択してください！',
+      noSelected: 'ファイルを選択してください',
       title: '削除',
     },
     newFile: {
       fieldName: 'ファイル名',
-      fieldFeedback: '同名のファイルが既に存在します！',
+      fieldFeedback: '同名のファイルが既に存在します',
       title: '新しいファイル生成',
     },
     newFolder: {
       fieldName: 'フォルダ名',
-      fieldFeedback: '同名のフォルダが既に存在します！',
+      fieldFeedback: '同名のフォルダが既に存在します',
       title: '新しいフォルダ生成',
     },
     preview: {
@@ -114,13 +114,13 @@ const ja = {
       title: '名前変更',
     },
     status: {
-      noErrors: 'エラーはありません！',
+      noErrors: 'エラーはありません',
       title: '状態',
     },
     upload: {
       ifExist: 'ファイルが既に存在する場合:',
-      noSelected: 'ファイルを選択してください！',
-      overwrite: '上書きします！',
+      noSelected: 'ファイルを選択してください',
+      overwrite: '上書きします',
       selected: '選択:',
       size: 'サイズ:',
       skip: 'スキップ',
@@ -138,7 +138,7 @@ const ja = {
     zip: {
       title: 'アーカイブ生成',
       fieldName: 'アーカイブ名',
-      fieldFeedback: 'アーカイブが既に存在します！',
+      fieldFeedback: 'アーカイブが既に存在します',
     },
     unzip: {
       title: 'アーカイブ解凍',
@@ -146,8 +146,8 @@ const ja = {
       fieldRadioName: '解凍先:',
       fieldRadio1: '現在フォルダ',
       fieldRadio2: '新しいフォルダ',
-      fieldFeedback: 'フォルダが既に存在します！',
-      warning: '注意！同名の場合、ファイルが上書きされます！',
+      fieldFeedback: 'フォルダが既に存在します',
+      warning: '注意同名の場合、ファイルが上書きされます',
     },
     cropper: {
       title: '切り出し',
@@ -157,36 +157,36 @@ const ja = {
     },
   },
   notifications: {
-    cutToClipboard: 'クリップボードに切り取りしました！',
-    copyToClipboard: 'クリップボードにコピーしました！',
-    copyUrl: 'URLをコピーしました！',
+    cutToClipboard: 'クリップボードに切り取りしました',
+    copyToClipboard: 'クリップボードにコピーしました',
+    copyUrl: 'URLをコピーしました',
   },
   response: {
-    noConfig: '設定が見つかりませんでした！',
-    notFound: '見つかりませんでした！',
-    diskNotFound: 'ディスクが見つかりませんでした！',
-    pathNotFound: 'パスが見つかりませんでした！',
-    diskSelected: 'ディスクを選択しました！',
+    noConfig: '設定が見つかりませんでした',
+    notFound: '見つかりませんでした',
+    diskNotFound: 'ディスクが見つかりませんでした',
+    pathNotFound: 'パスが見つかりませんでした',
+    diskSelected: 'ディスクを選択しました',
     // files
-    fileExist: 'ファイルが既に存在します！',
-    fileCreated: 'ファイルを生成しました！',
-    fileUpdated: 'ファイルを更新しました！',
-    fileNotFound: 'ファイルが見つかりませんでした！',
+    fileExist: 'ファイルが既に存在します',
+    fileCreated: 'ファイルを生成しました',
+    fileUpdated: 'ファイルを更新しました',
+    fileNotFound: 'ファイルが見つかりませんでした',
     // directories
-    dirExist: 'フォルダが既に存在します！',
-    dirCreated: 'フォルダを生成しました！',
+    dirExist: 'フォルダが既に存在します',
+    dirCreated: 'フォルダを生成しました',
     dirNotFound: 'フォルダが見つかりませんでした',
     // actions
-    uploaded: 'ファイルを全てアップロードしました！',
-    notAllUploaded: 'ファイルの一部がアップロードできませんでした！',
-    delNotFound: '一部項目が見つかりませんでした！',
-    deleted: '削除しました！',
-    renamed: '名前変更しました！',
-    copied: 'コピーしました！',
+    uploaded: 'ファイルを全てアップロードしました',
+    notAllUploaded: 'ファイルの一部がアップロードできませんでした',
+    delNotFound: '一部項目が見つかりませんでした',
+    deleted: '削除しました',
+    renamed: '名前変更しました',
+    copied: 'コピーしました',
     // zip
-    zipError: 'アーカイブ生成にエラーが発生しました！',
+    zipError: 'アーカイブ生成にエラーが発生しました',
     // acl
-    aclError: 'アクセスが拒否されました！',
+    aclError: '権限がありません',
   },
 };
 

--- a/src/lang/ja.js
+++ b/src/lang/ja.js
@@ -147,7 +147,7 @@ const ja = {
       fieldRadio1: '現在フォルダ',
       fieldRadio2: '新しいフォルダ',
       fieldFeedback: 'フォルダが既に存在します',
-      warning: '注意同名の場合、ファイルが上書きされます',
+      warning: '注意 : 同名の場合、ファイルが上書きされます',
     },
     cropper: {
       title: '切り出し',


### PR DESCRIPTION
## プルリク概要
ja.jsファイル変更
- 各メッセージの「！」マーク削除
- 「ディレクトリ」→「フォルダ」に変更
- ACLエラーの「アクセスが拒否されました」
　→ 「権限がありません」に変更
　（エラーメッセージが表示された理由が分かりづらいため）

・経緯：https://github.com/beyonds-inc/eportal-saas/pull/272

## 関連issue
■ ePortal
[#207 ](https://github.com/beyonds-inc/eportal-saas/issues/207)
[#272 ](https://github.com/beyonds-inc/eportal-saas/pull/272)