### PR TITLE
アクセス権限がないパスにアクセス時、リダイレクトさせる

### DIFF
--- a/src/store/actions.js
+++ b/src/store/actions.js
@@ -109,6 +109,10 @@ export default {
         GET.content(disk, path).then((response) => {
             if (response.data.result.status === 'success') {
                 context.commit(`${manager}/setDirectoryContent`, response.data);
+            } else {
+                // アクセス権限がない場合、ディスク最上位ディレクトリに移動
+                context.commit(`${manager}/setSelectedDirectory`, null);
+                context.dispatch(`${manager}/refreshDirectory`);
             }
         });
     },


### PR DESCRIPTION
## プルリク概要
アクセス権限がないパスにアクセス時、ディスク最上位パスにリダイレクトされるように修正

・経緯：https://github.com/beyonds-inc/eportal-saas/issues/266

## 関連issue
■ ePortal
[#266](https://github.com/beyonds-inc/eportal-saas/issues/266)
[#289](https://github.com/beyonds-inc/eportal-saas/pull/289)