### PR TITLE
「全施設共通」及び「施設別」のアイコンのサイズ変更

### DIFF
--- a/src/components/manager/DiskList.vue
+++ b/src/components/manager/DiskList.vue
@@ -64,5 +64,10 @@ export default {
     .badge.bg-light {
         cursor: pointer;
     }
+
+    .badge {
+        padding: 10px;
+        font-size: 100%;
+    }
 }
 </style>


### PR DESCRIPTION
## プルリク概要
資料一覧の「全施設共通」及び「施設別」のアイコンのサイズを大きくする

## 関連issue
https://github.com/beyonds-inc/eportal-saas/issues/313

## 改修内容
既存の`.badge`クラスに以下のスタイルを上書きする。
・padding
・font-size

## 単体テスト結果（エビデンス）


![スクリーンショット 2024-07-30 234934](https://github.com/user-attachments/assets/7e5ad6d2-9ef1-4321-a32d-06d50c55fb9f)
