### PR TITLE
資料アップロードボタンの位置変更

### DIFF
--- a/src/components/blocks/NavbarBlock.vue
+++ b/src/components/blocks/NavbarBlock.vue
@@ -1,7 +1,7 @@
 <template>
     <div class="fm-navbar mb-3">
         <div class="row justify-content-between">
-            <div class="col-auto">
+            <div class="col-auto d-flex ml-4">
                 <div class="btn-group" role="group">
                     <button
                         type="button"
@@ -20,6 +20,17 @@
                     >
                         <i class="bi bi-clipboard"></i>
                     </button>
+                </div>
+                <div>
+                    <a
+                        id="upload-link-button"
+                        :href="uploadUrl"
+                        class="ml-4 btn back-blue bluebtn-hover shadow roundness-10"
+                        role="button"
+                        style="color: #fff;"
+                    >
+                    <span class="pre">資料アップロード</span>
+                    </a>
                 </div>
             </div>
         </div>

--- a/src/components/blocks/NavbarBlock.vue
+++ b/src/components/blocks/NavbarBlock.vue
@@ -24,7 +24,6 @@
                 <div>
                     <a
                         id="upload-link-button"
-                        :href="uploadUrl"
                         class="ml-4 btn back-blue bluebtn-hover shadow roundness-10"
                         role="button"
                         style="color: #fff;"


### PR DESCRIPTION
# プルリク概要
資料アップロードボタンの位置を右上ではなく、新規フォルダ作成ボタンなどの横に変更
## 関連issue
https://github.com/beyonds-inc/eportal-saas/issues/318

## 改修内容
`<div class="btn-group" role="group">`
内にあるボタンと横並びになるようにflexboxを使用し
```
<div>  
    <a
        id="upload-link-button"
        :href="uploadUrl"
        class="ml-4 btn back-blue bluebtn-hover shadow roundness-10"
        role="button"
        style="color: #fff;"
      >
      <span class="pre">資料アップロード</span>
      </a>
</div>
```
を追記
## 単体テスト結果（エビデンス）
![スクリーンショット 2024-08-06 134122](https://github.com/user-attachments/assets/50a2c1cd-1b9d-418f-aee4-da58a58c7199)
