### PR TITLE
資料名表示時、他の資料の文字が隠れないよう表示位置を右に修正

### DIFF
--- a/src/components/manager/TableView.vue
+++ b/src/components/manager/TableView.vue
@@ -345,7 +345,6 @@ export default {
 
     .description {
         max-width: 200px;
-        position: relative;
         white-space: nowrap;
         overflow: hidden;
         text-overflow: ellipsis;
@@ -368,7 +367,7 @@ export default {
         width: 400px;
         position: absolute;
         top: 0;
-        left: 0;
+        right: 0;
     }
 
     .image-popup-wrapper img {


### PR DESCRIPTION
## プルリク概要
資料名にカーソル合わせたときに他の資料の文字が隠れないように資料名表示位置を右端に修正

## 関連issue
https://github.com/beyonds-inc/eportal-saas/issues/314

## 改修内容
```
.title-popup-wrapper, .description-popup-wrapper, .image-popup-wrapper {
　　width: 400px;
　　position: absolute;
　　top: 0;
　　left: 0;
}
```
`left: 0 → right: 0`にすることで右端に資料名が表示されるように修正。

```
.description {
　　max-width: 200px;
　　position: relative
　　white-space: nowrap;
　　overflow: hidden;
　　text-overflow: ellipsis;
}　
```
`position: relative`を削除することで、説明にカーソルを合わせても右端に資料名が表示されるように修正。

## 単体テスト項目
・資料名にカーソルを合わせると右端に資料名表示されること
・説明が登録されている場合、説明にカーソルを合わせると右端に資料名表示されること


## 単体テスト結果（エビデンス）
https://github.com/user-attachments/assets/c9958ab2-4e9a-4d3a-940b-69110c1417ae
https://github.com/user-attachments/assets/402d9f8a-4697-42c4-9406-9cea678c0d35

