### PR TITLE
ファイルの名前変更機能の復活・ファイル名が変わってもURLが不変になるように改修

### DIFF
--- a/src/components/blocks/mixins/contextMenuActions.js
+++ b/src/components/blocks/mixins/contextMenuActions.js
@@ -113,8 +113,8 @@ export default {
          */
         async copyUrlAction() {
             // ファイルのアクセスリンクを取得するAPIエンドポイント
-            const GET_FILE_LINK_ENDPOINT = '/api/materials/get-file-link';
-            const api_url = window.location.origin + GET_FILE_LINK_ENDPOINT;
+            const GET_MATERIAL_LINK_ENDPOINT = '/api/materials/get-material-link';
+            const api_url = window.location.origin + GET_MATERIAL_LINK_ENDPOINT;
             const data = {
                 disk: this.selectedDisk,
                 path: this.selectedItems[0].path,

--- a/src/components/blocks/mixins/contextMenuRules.js
+++ b/src/components/blocks/mixins/contextMenuRules.js
@@ -97,8 +97,7 @@ export default {
          * @returns {boolean}
          */
         renameRule() {
-            // return !this.multiSelect && this.$store.getters['fm/isEverySelectedItemRW'];
-            return false;
+            return !this.multiSelect && this.$store.getters['fm/isEverySelectedItemRW'];
         },
 
         /**


### PR DESCRIPTION
## 機能要望概要
- ファイルの名前変更機能の復活
- DBのファイルIDに基づいたファイル表示URLを生成・コピーできるようにする

## 目的
- ファイルの名前変更機能の復活
- ファイル名が変わってもURLが不変になるようにする

## 背景
- 先方のファイルの名前変更機能復活の要望
- 名前変更の復活により、既存のファイル名が変更できるようになる
  → 既存のURLにはファイル名が入ってるため、ファイル名が変わるとメール内URLや記事内URLからアクセスできなくなる

## 実装方法
- ファイルの名前変更機能の復活
  → コメントアウトにより非表示処理していたところを戻す
- DBのファイルIDに基づいたファイル表示URLを生成・コピーできるようにする
  - （バックエンド）DBのファイルIDに基づいたファイル表示URLを返すAPIを作成
  - （フロントエンド）URLコピー実行時、上記APIのエンドポイントにリクエストを送信。返ってきたレスポンス中のURLをクリップボードにコピーする。

## 参考URL
https://github.com/beyonds-inc/eportal-saas/issues/315