### PR TITLE
ファイルの名前変更時に拡張子は変更不可とする

### DIFF
--- a/src/components/modals/views/RenameModal.vue
+++ b/src/components/modals/views/RenameModal.vue
@@ -7,15 +7,18 @@
         <div class="modal-body">
             <div class="form-group">
                 <label for="fm-input-rename">{{ lang.modal.rename.fieldName }}</label>
-                <input
-                    type="text"
-                    class="form-control"
-                    id="fm-input-rename"
-                    v-focus
-                    v-bind:class="{ 'is-invalid': checkName }"
-                    v-model="name"
-                    v-on:keyup="validateName"
-                />
+                <div class="flex">
+                    <input
+                        type="text"
+                        class="form-control"
+                        id="fm-input-rename"
+                        v-focus
+                        v-bind:class="{ 'is-invalid': checkName }"
+                        v-model="filename"
+                        v-on:keyup="validateName"
+                    />
+                    <label for="fm-input-rename" v-show="extension !== ''">.{{ extension }}</label>
+                </div>
                 <div class="invalid-feedback" v-show="checkName">
                     {{ lang.modal.rename.fieldFeedback }}
                     {{ directoryExist ? ` - ${lang.modal.rename.directoryExist}` : '' }}
@@ -25,7 +28,7 @@
         </div>
         <div class="modal-footer">
             <button type="button" class="btn btn-info" v-bind:disabled="submitDisable" v-on:click="rename">
-                {{ lang.btn.submit }}
+                {{ lang.btn.save }}
             </button>
             <button type="button" class="btn btn-light" v-on:click="hideModal">{{ lang.btn.cancel }}</button>
         </div>
@@ -41,7 +44,8 @@ export default {
     mixins: [modal, translate],
     data() {
         return {
-            name: '',
+            filename: '',
+            extension: '',
             directoryExist: false,
             fileExist: false,
         };
@@ -60,7 +64,7 @@ export default {
          * @returns {boolean}
          */
         checkName() {
-            return this.directoryExist || this.fileExist || !this.name;
+            return this.directoryExist || this.fileExist || !this.filename;
         },
 
         /**
@@ -68,26 +72,34 @@ export default {
          * @returns {*|boolean}
          */
         submitDisable() {
-            return this.checkName || this.name === this.selectedItem.basename;
+            return this.checkName || this.basename === this.selectedItem.basename;
+        },
+
+        /**
+         * file name + extension 
+         */
+        basename() {
+            return this.extension === '' ? this.filename : this.filename + '.' + this.extension;
         },
     },
     mounted() {
         // initiate item name
-        this.name = this.selectedItem.basename;
+        this.filename = this.selectedItem.filename;
+        this.extension = this.selectedItem.extension;
     },
     methods: {
         /**
          * Validate item name
          */
         validateName() {
-            if (this.name !== this.selectedItem.basename) {
+            if (this.basename !== this.selectedItem.basename) {
                 // if item - folder
                 if (this.selectedItem.type === 'dir') {
                     // check folder name matches
-                    this.directoryExist = this.$store.getters[`fm/${this.activeManager}/directoryExist`](this.name);
+                    this.directoryExist = this.$store.getters[`fm/${this.activeManager}/directoryExist`](this.basename);
                 } else {
                     // check file name matches
-                    this.fileExist = this.$store.getters[`fm/${this.activeManager}/fileExist`](this.name);
+                    this.fileExist = this.$store.getters[`fm/${this.activeManager}/fileExist`](this.basename);
                 }
             }
         },
@@ -97,7 +109,7 @@ export default {
          */
         rename() {
             // create new name with path
-            const newName = this.selectedItem.dirname ? `${this.selectedItem.dirname}/${this.name}` : this.name;
+            const newName = this.selectedItem.dirname ? `${this.selectedItem.dirname}/${this.basename}` : this.basename;
 
             this.$store
                 .dispatch('fm/rename', {
@@ -113,3 +125,9 @@ export default {
     },
 };
 </script>
+<style scoped>
+.flex {
+    display: flex;
+    align-items: baseline;
+}
+</style>

--- a/src/lang/ar.js
+++ b/src/lang/ar.js
@@ -24,6 +24,7 @@ const ar = {
         upload: 'رفع',
         uploadSelect: 'اختر الملفات',
         hidden: 'الملفات المخفية',
+        save: 'حفظ',
     },
     clipboard: {
         actionType: 'نوع',

--- a/src/lang/cs.js
+++ b/src/lang/cs.js
@@ -25,6 +25,7 @@ const cs = {
         upload: 'Nahrát',
         uploadSelect: 'Vybrat soubory',
         hidden: ' Skryté soubory',
+        save: 'Uložit',
     },
     clipboard: {
         actionType: 'Typ',

--- a/src/lang/de.js
+++ b/src/lang/de.js
@@ -24,6 +24,7 @@ const de = {
         upload: 'Hochladen',
         uploadSelect: 'Auswählen',
         hidden: ' Versteckte Dateien',
+        save: 'Speichern',
     },
     clipboard: {
         actionType: 'Type',

--- a/src/lang/en.js
+++ b/src/lang/en.js
@@ -24,6 +24,7 @@ const en = {
         upload: 'Upload',
         uploadSelect: 'Select files',
         hidden: ' Hidden files',
+        save: 'Save',
     },
     clipboard: {
         actionType: 'Type',

--- a/src/lang/es.js
+++ b/src/lang/es.js
@@ -25,6 +25,7 @@ const es = {
         upload: 'Subir',
         uploadSelect: 'Seleccionar archivos',
         hidden: ' Archivos ocultos',
+        save: 'Guardar',
     },
     clipboard: {
         actionType: 'Tipo',

--- a/src/lang/fa.js
+++ b/src/lang/fa.js
@@ -25,6 +25,7 @@ const fa = {
         upload: 'بارگذاری',
         uploadSelect: 'انتخاب فایل',
         hidden: ' فایل های مخفی',
+        save: 'ذخیره',
     },
     clipboard: {
         actionType: 'نوع',

--- a/src/lang/fr.js
+++ b/src/lang/fr.js
@@ -24,6 +24,7 @@ const fr = {
         upload: 'Télécharger',
         uploadSelect: 'Sélectionner fichiers',
         hidden: ' Masquer fichiers',
+        save: 'Sauvegarder',
     },
     clipboard: {
         actionType: 'Type',

--- a/src/lang/hu.js
+++ b/src/lang/hu.js
@@ -25,6 +25,7 @@ const hu = {
         upload: 'Feltöltés',
         uploadSelect: 'Fájlok kiválasztása',
         hidden: ' Rejtett fájlok',
+        save: 'Mentés',
     },
     clipboard: {
         actionType: 'Típus',

--- a/src/lang/it.js
+++ b/src/lang/it.js
@@ -25,6 +25,7 @@ const it = {
         upload: 'Upload',
         uploadSelect: 'Seleziona files',
         hidden: ' Files Nascosti',
+        save: 'Salva',
     },
     clipboard: {
         actionType: 'Tipo',

--- a/src/lang/ja.js
+++ b/src/lang/ja.js
@@ -24,6 +24,7 @@ const ja = {
     upload: 'アップロード',
     uploadSelect: 'ファイル選択',
     hidden: ' 隠しファイル',
+    save: '保存',
   },
   clipboard: {
     actionType: 'タイプ',

--- a/src/lang/nl.js
+++ b/src/lang/nl.js
@@ -27,6 +27,7 @@ const nl = {
         upload: 'Uploaden',
         uploadSelect: 'Selecteer bestanden',
         hidden: ' Verborgen bestanden',
+        save: 'Opslaan',
     },
     clipboard: {
         actionType: 'Type',

--- a/src/lang/pl.js
+++ b/src/lang/pl.js
@@ -24,6 +24,7 @@ const pl = {
         upload: 'Wyślij plik',
         uploadSelect: 'Wybierz pliki',
         hidden: 'Ukryte pliki',
+        save: 'Zapisz',
     },
     clipboard: {
         actionType: 'Rodzaj',

--- a/src/lang/pt_BR.js
+++ b/src/lang/pt_BR.js
@@ -25,6 +25,7 @@ const pt_BR = {
         upload: 'Upload',
         uploadSelect: 'Selecionar arquivos',
         hidden: ' Arquivos ocultos',
+        save: 'Salvar',
     },
     clipboard: {
         actionType: 'Formato',

--- a/src/lang/ru.js
+++ b/src/lang/ru.js
@@ -24,6 +24,7 @@ const ru = {
         upload: 'Загрузить',
         uploadSelect: 'Выбрать файлы',
         hidden: 'Скрытые файлы',
+        save: 'Сохранить',
     },
     clipboard: {
         actionType: 'Тип операции',

--- a/src/lang/sr.js
+++ b/src/lang/sr.js
@@ -25,6 +25,7 @@ const sr = {
         upload: 'Upload',
         uploadSelect: 'Izaberi datoteke',
         hidden: ' Skrivene datoteke',
+        save: 'Sačuvaj',
     },
     clipboard: {
         actionType: 'Tip operacije',

--- a/src/lang/tr.js
+++ b/src/lang/tr.js
@@ -24,6 +24,7 @@ const tr = {
         upload: 'Yükle',
         uploadSelect: 'Dosyaları seç',
         hidden: ' Gizli dosyalar',
+        save: 'Kaydet',
     },
     clipboard: {
         actionType: 'İşlem türü',

--- a/src/lang/zh_CN.js
+++ b/src/lang/zh_CN.js
@@ -26,6 +26,7 @@ const zh_CN = {
         upload: '上传',
         uploadSelect: '选择文件',
         hidden: ' 隐藏文件',
+        save: '保存',
     },
     clipboard: {
         actionType: '类型',

--- a/src/lang/zh_TW.js
+++ b/src/lang/zh_TW.js
@@ -25,6 +25,7 @@ const zh_TW = {
         upload: '上傳',
         uploadSelect: '選擇文件',
         hidden: ' 隱藏文件',
+        save: '儲存',
     },
     clipboard: {
         actionType: '類型',


### PR DESCRIPTION
## プルリク概要
【client/medical：アップロードファイルの名前変更】ファイルの名前変更時に拡張子は変更不可とする
## 関連issue
https://github.com/beyonds-inc/eportal-saas/issues/352

## 改修内容
・名前変更フィールドにおいて、最後のピリオドより前の部分だけしか変更できないようにする。
・合わせて「送信」ボタンを「保存」に名称変更する

## 単体テスト項目
・名称変更フィールドおよび拡張子ラベル表示が妥当であること
　名称変更フィールド：最後のピリオドより前の部分が表示されること
　拡張子ラベル：（拡張子「有」の場合）最後のピリオドを含む後ろの部分が表示されること
　　　　　　　　（拡張子「無」の場合）ラベル表示されないこと。

　※ ファイル名のバリエーション
　　拡張子有（例：test.jpg）
　　拡張子無（例：test）
　　ピリオド複数（例：test.test.xlsx）
　　
　※ ファイル種類
　　docx／xlsx／jpg／jpeg／txt／pdf／mp4

・「送信」ボタンが「保存」に名称変更されていること。
・ファイル名の変更できること。また、ファイルの拡張子（タイプ）が変更されていないこと。（資料一覧画面にて確認）
　※ 変更後のファイル名のバリエーション
　　変更前：拡張子無／有
　　変更後：任意の文字、ピリオド＋任意の文字、ピリオドのみ（1つ）、ピリオドのみ（2つ以上）

・ファイル名の変更後、再度名前変更モーダルを開き、名称変更フィールド・拡張子ラベルの表示内容が問題ないこと。
・ファイル名の変更後、プレビューが行えること。

## 単体テスト結果（エビデンス）
■ 名称変更フィールドおよび拡張子ラベル表示が妥当であること
＜ファイル名のバリエーション＞
・拡張子有（例：test.jpg）
![image](https://github.com/user-attachments/assets/8a64fea1-802b-4634-a6bb-aa9f0cd1738a)
・拡張子無（test）
![image](https://github.com/user-attachments/assets/e25d7d7d-9ba3-42f3-8744-2612c7069e0b)
・ピリオド複数（test.test.jpg）
![image](https://github.com/user-attachments/assets/f22ba50f-637e-451a-8e21-a595c5e95cd3)

＜ファイル種類＞
・docx
![image](https://github.com/user-attachments/assets/b5d6a79a-48f3-4c6e-952f-c3f5b4668367)
・jpeg
![image](https://github.com/user-attachments/assets/5ed704e0-67bf-4e3b-839f-dfe1f0fce6d2)
・jpg
![image](https://github.com/user-attachments/assets/f121c67f-1404-4960-8419-ab7073ee176c)
・mp4
![image](https://github.com/user-attachments/assets/a83f5457-6324-42d7-b599-b9c6a8247a1f)
・pdf
![image](https://github.com/user-attachments/assets/305a25c2-4464-4919-bae9-dae779cdf882)
・txt
![image](https://github.com/user-attachments/assets/52fc3c19-2671-472b-8629-2c6c72abe48f)
・xlsx
![image](https://github.com/user-attachments/assets/5b4c9c92-b68a-430f-b7a6-7bc3f270f99a)

■ 「送信」ボタンが「保存」に名称変更されていること。
![image](https://github.com/user-attachments/assets/8a64fea1-802b-4634-a6bb-aa9f0cd1738a)

■ ファイル名の変更できること／ファイルの拡張子（タイプ）が変更されていないこと。（資料一覧画面で確認）
・拡張子無
![image](https://github.com/user-attachments/assets/5550db4a-c618-4d03-b9e4-66650a28b9b9)
↓
![image](https://github.com/user-attachments/assets/bf580a48-5eaf-427b-9bf9-e34bce44908a)

・拡張子有
![image](https://github.com/user-attachments/assets/6c6448dd-1ac1-473b-8a2e-b6bc6cf00c4c)
↓
![image](https://github.com/user-attachments/assets/1d908972-eefb-4730-bb3a-6d1972e46720)

■ ファイル名の変更後、再度名前変更モーダルを開き、名称変更フィールド・拡張子ラベルの表示内容が問題ないこと。
・変更前
![image](https://github.com/user-attachments/assets/b30f993f-8036-4ed7-b4f1-f1b0fc2bb420)
![image](https://github.com/user-attachments/assets/57865093-18b8-4ad5-86b0-d789502e93f2)

・変更後
![image](https://github.com/user-attachments/assets/c63aa3f7-9e34-4862-94f9-8dfbe32e2f6a)
![image](https://github.com/user-attachments/assets/23d7af33-a3e2-4b3f-bb3b-0ed49c4f17b7)

■ ファイル名の変更後、プレビューが行えること。
![image](https://github.com/user-attachments/assets/d3c6f8a4-f223-4a22-a8c1-ecfa62f2fd26)
![image](https://github.com/user-attachments/assets/e398a1e9-2c75-4e8c-acf8-0201d781dc77)

