### PR TITLE
フォルダ右クリック時、「名前変更」メニューが出る

### DIFF
--- a/src/components/blocks/mixins/contextMenuRules.js
+++ b/src/components/blocks/mixins/contextMenuRules.js
@@ -97,7 +97,7 @@ export default {
          * @returns {boolean}
          */
         renameRule() {
-            return !this.multiSelect && this.$store.getters['fm/isEverySelectedItemRW'];
+            return !this.multiSelect && this.firstItemType === 'file' && this.$store.getters['fm/isEverySelectedItemRW'];
         },
 
         /**


### PR DESCRIPTION
## プルリク概要
【管理者：資料一覧】フォルダ右クリック時、「名前変更」メニューが出る 

## 関連issue
[#353](https://github.com/beyonds-inc/eportal-saas/issues/353)

## 改修内容
・資料一覧画面にて、タイプ=フォルダにおいては「名前変更」メニューを隠す。

## 単体テスト項目
資料一覧画面にて、タイプに応じて「名前変更」メニューの表示制御が正しいこと。
・タイプ=フォルダ　　　：非表示
・タイプ=フォルダ以外　：表示

※ client / medicalどちらでも確認する。

## 単体テスト結果（エビデンス）
・タイプ=フォルダ
![image](https://github.com/user-attachments/assets/01061be4-d4a2-4711-b3b7-b4df647011d4)

・タイプ=フォルダ以外
タイプ = なし
![image](https://github.com/user-attachments/assets/2d4d83e3-9d55-44d7-aa10-eb6564065407)

タイプ = docx
![image](https://github.com/user-attachments/assets/606cf5ab-cbeb-49c9-badd-267839696991)

タイプ = mp4
![image](https://github.com/user-attachments/assets/f4d6ec90-26d0-4022-8f61-c28d06b99893)

タイプ = jpg
![image](https://github.com/user-attachments/assets/dda300ec-85c3-43ed-9f6c-b145013db767)

タイプ = jpeg
![image](https://github.com/user-attachments/assets/1bd49e42-4fa5-4c99-b3cf-6135b166026a)

タイプ = pdf
![image](https://github.com/user-attachments/assets/5986227c-d22c-4fdb-a36c-635da13f5cef)

タイプ = txt
![image](https://github.com/user-attachments/assets/ecce4fb4-4423-40b1-8e73-2e779726c5fe)
