### PR TITLE
【client/medical共通】ファイルバージョン履歴表示機能のUI実装

### DIFF
--- a/src/components/blocks/mixins/contextMenuActions.js
+++ b/src/components/blocks/mixins/contextMenuActions.js
@@ -264,5 +264,16 @@ export default {
                 show: true,
             });
         },
+
+        /**
+         * Show version history for selected file
+         */
+        versionsAction() {
+            // show modal - version history
+            this.$store.commit('fm/modal/setModalState', {
+                modalName: 'VersionsModal',
+                show: true,
+            });
+        },
     },
 };

--- a/src/components/blocks/mixins/contextMenuRules.js
+++ b/src/components/blocks/mixins/contextMenuRules.js
@@ -153,5 +153,13 @@ export default {
             // return !this.multiSelect;
             return false;
         },
+
+        /**
+         * Versions - menu item status - show or hide
+         * @returns {boolean}
+         */
+        versionsRule() {
+            return !this.multiSelect && this.firstItemType === 'file';
+        },
     },
 };

--- a/src/components/modals/ModalBlock.vue
+++ b/src/components/modals/ModalBlock.vue
@@ -24,6 +24,7 @@ import VideoPlayerModal from './views/VideoPlayerModal.vue';
 import ZipModal from './views/ZipModal.vue';
 import UnzipModal from './views/UnzipModal.vue';
 import AboutModal from './views/AboutModal.vue';
+import VersionsModal from './views/VersionsModal.vue';
 
 export default {
     name: 'ModalBlock',
@@ -43,6 +44,7 @@ export default {
         ZipModal,
         UnzipModal,
         AboutModal,
+        VersionsModal,
     },
     mounted() {
         // set height

--- a/src/components/modals/views/TextEditModal.vue
+++ b/src/components/modals/views/TextEditModal.vue
@@ -17,9 +17,9 @@
             />
         </div>
         <div class="modal-footer">
-            <button type="button" class="btn btn-info" v-on:click="updateFile">
+            <!--button type="button" class="btn btn-info" v-on:click="updateFile">
                 {{ lang.btn.submit }}
-            </button>
+            </button-->
             <button type="button" class="btn btn-light" v-on:click="hideModal">
                 {{ lang.btn.cancel }}
             </button>
@@ -104,6 +104,7 @@ export default {
                 theme: 'blackboard',
                 lineNumbers: true,
                 line: true,
+                readOnly: true,
             };
         },
 

--- a/src/components/modals/views/VersionsModal.vue
+++ b/src/components/modals/views/VersionsModal.vue
@@ -81,6 +81,18 @@ export default {
     },
     methods: {
         /**
+         * Get base URL with proper formatting
+         * @returns {string}
+         */
+        getBaseUrl() {
+            let baseUrl = this.$store.state.fm.settings.baseUrl;
+            if (baseUrl.endsWith('/')) {
+                baseUrl = baseUrl.slice(0, -1);
+            }
+            return baseUrl;
+        },
+        
+        /**
          * Get file versions
          */
         getVersions() {
@@ -88,7 +100,10 @@ export default {
             this.error = null;
 
             // API endpoint for getting file versions
-            const apiUrl = `${window.location.origin}/${this.$store.state.fm.settings.baseUrl}/versions?disk=${encodeURIComponent(this.selectedDisk)}&path=${encodeURIComponent(this.selectedItem.path)}`;
+            const baseUrl = this.getBaseUrl();
+            const apiUrl = baseUrl.startsWith('http')
+                ? `${baseUrl}/versions?disk=${encodeURIComponent(this.selectedDisk)}&path=${encodeURIComponent(this.selectedItem.path)}`
+                : `${window.location.origin}/${baseUrl}/versions?disk=${encodeURIComponent(this.selectedDisk)}&path=${encodeURIComponent(this.selectedItem.path)}`;
 
             fetch(apiUrl)
                 .then(response => {
@@ -117,7 +132,10 @@ export default {
          * @param {number} versionNumber
          */
         downloadVersion(versionNumber) {
-            const downloadUrl = `${window.location.origin}/${this.$store.state.fm.settings.baseUrl}/download-version?disk=${encodeURIComponent(this.selectedDisk)}&path=${encodeURIComponent(this.selectedItem.path)}&version=${versionNumber}`;
+            const baseUrl = this.getBaseUrl();
+            const downloadUrl = baseUrl.startsWith('http')
+                ? `${baseUrl}/download-version?disk=${encodeURIComponent(this.selectedDisk)}&path=${encodeURIComponent(this.selectedItem.path)}&version=${versionNumber}`
+                : `${window.location.origin}/${baseUrl}/download-version?disk=${encodeURIComponent(this.selectedDisk)}&path=${encodeURIComponent(this.selectedItem.path)}&version=${versionNumber}`;
 
             const tempLink = document.createElement('a');
             tempLink.style.display = 'none';

--- a/src/components/modals/views/VersionsModal.vue
+++ b/src/components/modals/views/VersionsModal.vue
@@ -29,11 +29,11 @@
                     <tbody>
                         <tr v-for="version in versions" :key="version.id">
                             <td>{{ version.version_number }}</td>
-                            <td>{{ timestampToDate(version.updated_at) }}</td>
-                            <td>{{ version.user ? version.user.name : '-' }}</td>
+                            <td>{{ timestampToDate(version.timestamp) }}</td>
+                            <td>{{ version.user_name ? version.user_name : '-' }}</td>
                             <td>
-                                <button 
-                                    class="btn btn-sm btn-primary" 
+                                <button
+                                    class="btn btn-sm btn-primary"
                                     v-on:click="downloadVersion(version.version_number)"
                                 >
                                     <i class="bi bi-download"></i> {{ lang.btn.download }}
@@ -86,10 +86,10 @@ export default {
         getVersions() {
             this.loading = true;
             this.error = null;
-            
+
             // API endpoint for getting file versions
             const apiUrl = `${window.location.origin}/api/materials/versions?disk=${encodeURIComponent(this.selectedDisk)}&path=${encodeURIComponent(this.selectedItem.path)}`;
-            
+
             fetch(apiUrl)
                 .then(response => {
                     if (!response.ok) {
@@ -111,14 +111,14 @@ export default {
                     this.loading = false;
                 });
         },
-        
+
         /**
          * Download specific version
          * @param {number} versionNumber
          */
         downloadVersion(versionNumber) {
             const downloadUrl = `${window.location.origin}/api/materials/download-version?disk=${encodeURIComponent(this.selectedDisk)}&path=${encodeURIComponent(this.selectedItem.path)}&version=${versionNumber}`;
-            
+
             const tempLink = document.createElement('a');
             tempLink.style.display = 'none';
             tempLink.href = downloadUrl;
@@ -135,14 +135,11 @@ export default {
 
 <style lang="scss">
 .fm-modal-versions {
-    .modal-body {
-        max-height: 70vh;
-        overflow-y: auto;
-    }
-    
     .table {
+        table-layout: auto;
         th, td {
             vertical-align: middle;
+            white-space: nowrap;
         }
     }
 }

--- a/src/components/modals/views/VersionsModal.vue
+++ b/src/components/modals/views/VersionsModal.vue
@@ -1,0 +1,149 @@
+<template>
+    <div class="modal-content fm-modal-versions">
+        <div class="modal-header">
+            <h5 class="modal-title">{{ lang.modal.versions.title }}</h5>
+            <button type="button" class="btn-close" aria-label="Close" v-on:click="hideModal"></button>
+        </div>
+        <div class="modal-body">
+            <div v-if="loading" class="text-center p-3">
+                <div class="spinner-border" role="status">
+                    <span class="visually-hidden">Loading...</span>
+                </div>
+            </div>
+            <div v-else-if="error" class="alert alert-danger">
+                {{ error }}
+            </div>
+            <div v-else-if="versions.length === 0" class="alert alert-info">
+                {{ lang.modal.versions.noVersions }}
+            </div>
+            <div v-else class="table-responsive">
+                <table class="table table-striped">
+                    <thead>
+                        <tr>
+                            <th>{{ lang.modal.versions.version }}</th>
+                            <th>{{ lang.modal.versions.date }}</th>
+                            <th>{{ lang.modal.versions.user }}</th>
+                            <th>{{ lang.modal.versions.action }}</th>
+                        </tr>
+                    </thead>
+                    <tbody>
+                        <tr v-for="version in versions" :key="version.id">
+                            <td>{{ version.version_number }}</td>
+                            <td>{{ timestampToDate(version.updated_at) }}</td>
+                            <td>{{ version.user ? version.user.name : '-' }}</td>
+                            <td>
+                                <button 
+                                    class="btn btn-sm btn-primary" 
+                                    v-on:click="downloadVersion(version.version_number)"
+                                >
+                                    <i class="bi bi-download"></i> {{ lang.btn.download }}
+                                </button>
+                            </td>
+                        </tr>
+                    </tbody>
+                </table>
+            </div>
+        </div>
+    </div>
+</template>
+
+<script>
+import modal from '../mixins/modal';
+import translate from '../../../mixins/translate';
+import helper from '../../../mixins/helper';
+
+export default {
+    name: 'VersionsModal',
+    mixins: [modal, translate, helper],
+    data() {
+        return {
+            versions: [],
+            loading: true,
+            error: null,
+        };
+    },
+    computed: {
+        /**
+         * Selected disk
+         * @returns {*}
+         */
+        selectedDisk() {
+            return this.$store.getters['fm/selectedDisk'];
+        },
+
+        /**
+         * Selected file
+         * @returns {*}
+         */
+        selectedItem() {
+            return this.$store.getters['fm/selectedItems'][0];
+        },
+    },
+    methods: {
+        /**
+         * Get file versions
+         */
+        getVersions() {
+            this.loading = true;
+            this.error = null;
+            
+            // API endpoint for getting file versions
+            const apiUrl = `${window.location.origin}/api/materials/versions?disk=${encodeURIComponent(this.selectedDisk)}&path=${encodeURIComponent(this.selectedItem.path)}`;
+            
+            fetch(apiUrl)
+                .then(response => {
+                    if (!response.ok) {
+                        throw new Error('Network response was not ok');
+                    }
+                    return response.json();
+                })
+                .then(data => {
+                    if (data.result.status === 'success') {
+                        this.versions = data.versions || [];
+                    } else {
+                        this.error = data.result.message || this.lang.modal.versions.error;
+                    }
+                    this.loading = false;
+                })
+                .catch(error => {
+                    console.error('Error fetching versions:', error);
+                    this.error = this.lang.modal.versions.error;
+                    this.loading = false;
+                });
+        },
+        
+        /**
+         * Download specific version
+         * @param {number} versionNumber
+         */
+        downloadVersion(versionNumber) {
+            const downloadUrl = `${window.location.origin}/api/materials/download-version?disk=${encodeURIComponent(this.selectedDisk)}&path=${encodeURIComponent(this.selectedItem.path)}&version=${versionNumber}`;
+            
+            const tempLink = document.createElement('a');
+            tempLink.style.display = 'none';
+            tempLink.href = downloadUrl;
+            document.body.appendChild(tempLink);
+            tempLink.click();
+            document.body.removeChild(tempLink);
+        },
+    },
+    mounted() {
+        this.getVersions();
+    },
+};
+</script>
+
+<style lang="scss">
+.fm-modal-versions {
+    .modal-body {
+        max-height: 70vh;
+        overflow-y: auto;
+    }
+    
+    .table {
+        th, td {
+            vertical-align: middle;
+        }
+    }
+}
+</style>

--- a/src/components/modals/views/VersionsModal.vue
+++ b/src/components/modals/views/VersionsModal.vue
@@ -88,7 +88,7 @@ export default {
             this.error = null;
 
             // API endpoint for getting file versions
-            const apiUrl = `${window.location.origin}/api/materials/versions?disk=${encodeURIComponent(this.selectedDisk)}&path=${encodeURIComponent(this.selectedItem.path)}`;
+            const apiUrl = `${window.location.origin}/${this.$store.state.fm.settings.baseUrl}/versions?disk=${encodeURIComponent(this.selectedDisk)}&path=${encodeURIComponent(this.selectedItem.path)}`;
 
             fetch(apiUrl)
                 .then(response => {
@@ -117,7 +117,7 @@ export default {
          * @param {number} versionNumber
          */
         downloadVersion(versionNumber) {
-            const downloadUrl = `${window.location.origin}/api/materials/download-version?disk=${encodeURIComponent(this.selectedDisk)}&path=${encodeURIComponent(this.selectedItem.path)}&version=${versionNumber}`;
+            const downloadUrl = `${window.location.origin}/${this.$store.state.fm.settings.baseUrl}/download-version?disk=${encodeURIComponent(this.selectedDisk)}&path=${encodeURIComponent(this.selectedItem.path)}&version=${versionNumber}`;
 
             const tempLink = document.createElement('a');
             tempLink.style.display = 'none';

--- a/src/lang/ja.js
+++ b/src/lang/ja.js
@@ -138,7 +138,7 @@ const ja = {
       title: 'ファイルアップロード',
     },
     editor: {
-      title: 'エディタ',
+      title: 'テキストビューア',
     },
     audioPlayer: {
       title: 'オーディオプレーヤー',

--- a/src/lang/ja.js
+++ b/src/lang/ja.js
@@ -51,6 +51,7 @@ const ja = {
     audioPlay: '再生',
     videoPlay: '動画再生',
     copyUrl: 'URLコピー',
+    versions: 'バージョン履歴',
   },
   info: {
     directories: 'フォルダ:',
@@ -106,6 +107,15 @@ const ja = {
       access_0: 'アクセス不可',
       access_1: '読み取り専用',
       access_2: '読み書き可能',
+    },
+    versions: {
+      title: 'ファイルバージョン履歴',
+      version: 'バージョン',
+      date: '更新日時',
+      user: '更新者',
+      action: 'アクション',
+      noVersions: 'バージョン履歴がありません',
+      error: 'バージョン履歴の取得に失敗しました',
     },
     rename: {
       directoryExist: 'ディレクトリが既に存在します',

--- a/src/store/settings/store.js
+++ b/src/store/settings/store.js
@@ -108,6 +108,10 @@ export default {
                     {
                         name: 'copyUrl',
                         icon: 'bi-link-45deg',
+                    },
+                    {
+                        name: 'versions',
+                        icon: 'bi-clock-history',
                     }
                 ],
                 [


### PR DESCRIPTION
## 概要
イシュー[#382](https://github.com/beyonds-inc/eportal-saas/issues/382) に対応し、ファイルアップロード時の過去バージョン保管・参照機能を追加。

[PR#385](https://github.com/beyonds-inc/eportal-saas/pull/385) のフロントエンドの対応。

## 変更内容

3. バージョン履歴表示機能の追加
   - ファイル一覧画面で右クリックメニューからバージョン履歴を表示
   - バージョン番号、更新日時、更新者を表示
   - 過去バージョンのダウンロード機能
