### PR TITLE
viewer権限時に編集系コンテキストメニューを非表示化

### DIFF
--- a/src/components/blocks/mixins/contextMenuRules.js
+++ b/src/components/blocks/mixins/contextMenuRules.js
@@ -89,7 +89,7 @@ export default {
          */
         cutRule() {
             // viewer権限の場合は非表示
-            if (window.isViewer !== undefined && window.isViewer) {
+            if (window.isViewer !== undefined && window.isViewer === '1') {
                 return false;
             }
             return this.$store.getters['fm/isEverySelectedItemRW'] && this.selectedItems.every((elem) => elem.type === 'file');
@@ -102,7 +102,7 @@ export default {
          */
         renameRule() {
             // viewer権限の場合は非表示
-            if (window.isViewer !== undefined && window.isViewer) {
+            if (window.isViewer !== undefined && window.isViewer === '1') {
                 return false;
             }
             return !this.multiSelect && this.$store.getters['fm/isEverySelectedItemRW'];
@@ -114,7 +114,7 @@ export default {
          */
         pasteRule() {
             // viewer権限の場合は非表示
-            if (window.isViewer !== undefined && window.isViewer) {
+            if (window.isViewer !== undefined && window.isViewer === '1') {
                 return false;
             }
             // return !!this.$store.state.fm.clipboard.type && this.$store.getters['fm/isEverySelectedItemRW'];
@@ -127,7 +127,7 @@ export default {
          */
         zipRule() {
             // viewer権限の場合は非表示
-            if (window.isViewer !== undefined && window.isViewer) {
+            if (window.isViewer !== undefined && window.isViewer === '1') {
                 return false;
             }
             // return this.selectedDiskDriver === 'local' && this.$store.getters['fm/isEverySelectedItemRW'];
@@ -140,7 +140,7 @@ export default {
          */
         unzipRule() {
             // viewer権限の場合は非表示
-            if (window.isViewer !== undefined && window.isViewer) {
+            if (window.isViewer !== undefined && window.isViewer === '1') {
                 return false;
             }
             // return (
@@ -159,7 +159,7 @@ export default {
          */
         deleteRule() {
             // viewer権限の場合は非表示
-            if (window.isViewer !== undefined && window.isViewer) {
+            if (window.isViewer !== undefined && window.isViewer === '1') {
                 return false;
             }
             // forbid medical users from deleting folders

--- a/src/components/blocks/mixins/contextMenuRules.js
+++ b/src/components/blocks/mixins/contextMenuRules.js
@@ -88,6 +88,10 @@ export default {
          * @returns {boolean}
          */
         cutRule() {
+            // viewer権限の場合は非表示
+            if (window.isViewer !== undefined && window.isViewer) {
+                return false;
+            }
             return this.$store.getters['fm/isEverySelectedItemRW'] && this.selectedItems.every((elem) => elem.type === 'file');
             // return false;
         },
@@ -97,6 +101,10 @@ export default {
          * @returns {boolean}
          */
         renameRule() {
+            // viewer権限の場合は非表示
+            if (window.isViewer !== undefined && window.isViewer) {
+                return false;
+            }
             return !this.multiSelect && this.$store.getters['fm/isEverySelectedItemRW'];
         },
 
@@ -105,6 +113,10 @@ export default {
          * @returns {boolean}
          */
         pasteRule() {
+            // viewer権限の場合は非表示
+            if (window.isViewer !== undefined && window.isViewer) {
+                return false;
+            }
             // return !!this.$store.state.fm.clipboard.type && this.$store.getters['fm/isEverySelectedItemRW'];
             return false;
         },
@@ -114,6 +126,10 @@ export default {
          * @returns {boolean}
          */
         zipRule() {
+            // viewer権限の場合は非表示
+            if (window.isViewer !== undefined && window.isViewer) {
+                return false;
+            }
             // return this.selectedDiskDriver === 'local' && this.$store.getters['fm/isEverySelectedItemRW'];
             return false;
         },
@@ -123,6 +139,10 @@ export default {
          * @returns {boolean}
          */
         unzipRule() {
+            // viewer権限の場合は非表示
+            if (window.isViewer !== undefined && window.isViewer) {
+                return false;
+            }
             // return (
             //     this.selectedDiskDriver === 'local' &&
             //     !this.multiSelect &&
@@ -138,6 +158,10 @@ export default {
          * @returns {boolean}
          */
         deleteRule() {
+            // viewer権限の場合は非表示
+            if (window.isViewer !== undefined && window.isViewer) {
+                return false;
+            }
             // forbid medical users from deleting folders
             if (!this.selectedItems.every((elem) => elem.type === 'file') && !window.isEditor) {
                 return false;


### PR DESCRIPTION
## プルリク概要
viewer権限ユーザーに対して、実行できない編集系のコンテキストメニューを非表示にする機能を実装しました。

## 関連プルリクエスト
https://github.com/beyonds-inc/eportal-saas/pull/607

## 関連issue
[#600 ](https://github.com/beyonds-inc/eportal-saas/issues/600)

## デプロイ時の影響
- [ ] .env の修正
- [ ] DBのテーブル/カラム追加・修正あり
- [ ] DBへのデータ投入・更新の必要あり

## 改修内容

### 背景

### 実装内容
`src/components/blocks/mixins/contextMenuRules.js` を修正し、以下のメニュールールに viewer権限チェックを追加：

1. **切り取り（cutRule）**
2. **名前変更（renameRule）**
3. **削除（deleteRule）**
4. **貼り付け（pasteRule）** ※将来の有効化に備えて
5. **ZIP（zipRule）** ※将来の有効化に備えて
6. **解凍（unzipRule）** ※将来の有効化に備えて

各ルールに以下のチェックを追加：
```javascript
// viewer権限の場合は非表示
if (window.isViewer !== undefined && window.isViewer) {
    return false;
}
```