### PR TITLE
フォルダの右クリックメニューから「名前変更」を非表示にする (#585)

### DIFF
--- a/src/components/blocks/mixins/contextMenuRules.js
+++ b/src/components/blocks/mixins/contextMenuRules.js
@@ -97,6 +97,10 @@ export default {
          * @returns {boolean}
          */
         renameRule() {
+            // フォルダ（施設名）の名前変更を禁止
+            if (this.firstItemType === 'dir') {
+                return false;
+            }
             return !this.multiSelect && this.$store.getters['fm/isEverySelectedItemRW'];
         },
 

--- a/src/components/blocks/mixins/contextMenuRules.js
+++ b/src/components/blocks/mixins/contextMenuRules.js
@@ -97,8 +97,8 @@ export default {
          * @returns {boolean}
          */
         renameRule() {
-            // フォルダ（施設名）の名前変更を禁止
-            if (this.firstItemType === 'dir') {
+            // 「施設別」ディスクのフォルダの名前変更を禁止
+            if (this.firstItemType === 'dir' && this.selectedDisk === '施設別') {
                 return false;
             }
             return !this.multiSelect && this.$store.getters['fm/isEverySelectedItemRW'];

--- a/src/components/blocks/mixins/contextMenuRules.js
+++ b/src/components/blocks/mixins/contextMenuRules.js
@@ -97,9 +97,13 @@ export default {
          * @returns {boolean}
          */
         renameRule() {
-            // 「施設別」ディスクのフォルダの名前変更を禁止
+            // 「施設別」ディスク直下のフォルダ（施設名）の名前変更を禁止
             if (this.firstItemType === 'dir' && this.selectedDisk === '施設別') {
-                return false;
+                const selectedDirectory = this.$store.getters['fm/selectedDirectory'];
+                // selectedDirectoryがnullまたは空の場合、ディスク直下のフォルダ
+                if (!selectedDirectory) {
+                    return false;
+                }
             }
             return !this.multiSelect && this.$store.getters['fm/isEverySelectedItemRW'];
         },


### PR DESCRIPTION
## プルリク概要
資料一覧＞施設別の画面で、施設名（フォルダ）を右クリックした際に表示される「名前変更」メニューを非表示にする対応です。

## 関連issue
- https://github.com/beyonds-inc/eportal-saas/issues/585

## 関連PR
https://github.com/beyonds-inc/eportal-saas/pull/621

## 改修内容
- `src/components/blocks/mixins/contextMenuRules.js` の `renameRule()` メソッドを修正