### PR TITLE
feat: 閲覧（PDF/Word プレビュー）を preview-download エンドポイントへ分離 (eportal-saas #785)

### DIFF
--- a/src/http/get.js
+++ b/src/http/get.js
@@ -66,13 +66,19 @@ export default {
     },
 
     /**
-     * Get file - ArrayBuffer
+     * Get file - ArrayBuffer (for in-browser preview / viewing)
+     *
+     * Uses the dedicated `preview-download` endpoint instead of `download`
+     * so that the audit trail can distinguish "閲覧（別タブで開く）" from
+     * "ダウンロード". See beyonds-inc/eportal-saas Issue #785 / PR #786.
+     * Only the openPDF flow (PDF preview and Word→PDF preview) uses this;
+     * the 3-dot menu download keeps using `download`.
      * @param disk
      * @param path
      * @returns {*}
      */
     getFileArrayBuffer(disk, path) {
-        return HTTP.get('download', {
+        return HTTP.get('preview-download', {
             responseType: 'arraybuffer',
             params: { disk, path },
         });


### PR DESCRIPTION
## 背景・課題

ファイルマネージャでは、ファイル名クリックでの**閲覧（別タブで開く）**と3点メニューの**ダウンロード**が、どちらも `GET /file-manager/download` を叩くため、監査証跡（`operation_logs`）上で区別できませんでした（Project audit で CRA のファイルダウンロード履歴として指摘）。

- バックエンド側で閲覧専用の `preview-download` エンドポイントを追加済み（eportal-saas PR #786、`fm.preview-download`）。本PRはそのフロント側対応です。
- これを行うまで監査ログ上の区別は実際には発生しません（バックエンドは受け入れ準備済み）。

## 変更内容

`src/http/get.js` の `getFileArrayBuffer()` の呼び出し先を `download` → `preview-download` に変更。

| フロー | 経路 | エンドポイント |
|---|---|---|
| PDF 閲覧 | `openPDF` → `getFileArrayBuffer` | `preview-download`（変更） |
| Word 閲覧 (docx/doc) | `word-to-pdf/convert` → `openPDF` → `getFileArrayBuffer` | `preview-download`（変更） |
| 3点メニュー ダウンロード | `downloadAction` → `download()` | `download`（従来どおり） |
| テキスト表示/編集 | `getFile()` | `download`（従来どおり） |
| 画像閲覧 | `preview()` | `preview`（既存・変更不要） |

`getFileArrayBuffer` の利用元は `store/actions.js` の `openPDF` のみで、閲覧系（PDF / Word→PDF）に限定されます。3点メニューの `download()` とは別関数のため影響しません。

## 監査証跡への効果（バックエンド側）

- 閲覧: `client/medical_material_preview`（「ファイル閲覧」）
- ダウンロード: `client/medical_material_download`（従来どおり）

## ビルド／反映について

本リポジトリは `dist` を Git 管理対象外（.gitignore）としています。実際の配信バンドル `laravel/public/vendor/file-manager/js/file-manager.js` への反映（ビルド＆コピー）は eportal-saas 側で別途行う必要があります。

## ADR について

CLAUDE.md / AGENTS.md は実装方式の意思決定の ADR 記録を求めていますが、`docs/adr/` の雛形は現状 `master` のみに存在し `dev` には未マージのため、本PRでは ADR を追加していません。エンドポイント分離方式の意思決定は eportal-saas Issue #785 に記録済みです。

## テスト

- `node --check src/http/get.js` 構文OK
- 変更は閲覧フローのエンドポイント文字列のみ（1関数）

Refs: beyonds-inc/eportal-saas#785, beyonds-inc/eportal-saas#786

🤖 Generated with [Claude Code](https://claude.com/claude-code)